### PR TITLE
Update for Rails 5 compatibility, use `public_file_server`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+- Added support for Rails 5.0 [#16](https://github.com/heroku/rails_serve_static_assets/pull/16)
+
 ## [0.0.4] - 2015-01-29
 
 - Reduce gem size on disk closes [#13](https://github.com/heroku/rails_serve_static_assets/issues/13)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Supports:
 
 - Rails 3
 - Rails 4
+- Rails 5
 
 ## What
 

--- a/lib/rails_serve_static_assets/railtie.rb
+++ b/lib/rails_serve_static_assets/railtie.rb
@@ -1,7 +1,10 @@
 module RailsServeStaticAssets
   class Railtie < Rails::Railtie
     config.before_initialize do
-      if Rails.version >= "4.2.0"
+      version = Rails.version
+      if version >= "5.0.0"
+        ::Rails.configuration.public_file_server.enabled = true
+      elsif version >= "4.2.0"
         ::Rails.configuration.serve_static_files = true
       else
         ::Rails.configuration.serve_static_assets = true


### PR DESCRIPTION
On Rails 5.0 the option now is called `public_file_server.enabled` (see
 https://github.com/rails/rails/commit/fa2c96b).

Thanks :smiley: 
